### PR TITLE
making clock root wire short by moving SRAMS around

### DIFF
--- a/bigblade_vcache/tcl/hard/gf_14/placement_constraints.tcl
+++ b/bigblade_vcache/tcl/hard/gf_14/placement_constraints.tcl
@@ -18,20 +18,20 @@ set stat_mem_path "cache/stat_mem/macro_mem"
 
 set data_mem_cell [get_cells -hier -filter "full_name=~$data_mem_path"]
 create_keepout_margin -type hard -outer "$margin_x $margin_y $margin_x $margin_y" $data_mem_cell
-set_macro_relative_location -target_object $data_mem_cell -target_corner br -target_orientation R0 \
-                                                          -anchor_corner br \
-                                                          -offset "-$margin_x [expr $margin_y*1]"
+set_macro_relative_location -target_object $data_mem_cell -target_corner bl -target_orientation MY \
+                                                          -anchor_corner bl \
+                                                          -offset "$margin_x [expr $margin_y*1]"
 
 set tag_mem_cell [get_cells -hier -filter "full_name=~$tag_mem_path"]
 create_keepout_margin -type hard -outer "$margin_x $margin_y $margin_x $margin_y" $tag_mem_cell
-set_macro_relative_location -target_object $tag_mem_cell -target_corner bl -target_orientation MY \
-                                                         -anchor_corner bl \
-                                                         -offset "$margin_x [expr $margin_y*1]"
+set_macro_relative_location -target_object $tag_mem_cell -target_corner br -target_orientation R0 \
+                                                         -anchor_corner br \
+                                                         -offset "-$margin_x [expr $margin_y*1]"
 
 set stat_mem_cell [get_cells -hier -filter "full_name=~$stat_mem_path"]
 create_keepout_margin -type hard -outer "$margin_x $margin_y $margin_x $margin_y" $stat_mem_cell
-set_macro_relative_location -target_object $stat_mem_cell -target_corner bl -target_orientation MY \
+set_macro_relative_location -target_object $stat_mem_cell -target_corner br -target_orientation R0 \
                                                           -anchor_object $tag_mem_cell \
-                                                          -anchor_corner tl -offset "0 [expr $margin_y*1]"
+                                                          -anchor_corner tr -offset "0 [expr $margin_y*1]"
 
 puts "BSG-info: Completed script [info script]\n"


### PR DESCRIPTION
- reduce global skew by 10%
- reduce max latency by 20%
- reduce inverter lvl to 5 from 7.
- reduce leakage/dynamic power by 6%/2%