### PR TITLE
Restore disable timing before etm generation

### DIFF
--- a/bigblade_bp_unicore/tcl/hard/gf_14/etm_pre_script.tcl
+++ b/bigblade_bp_unicore/tcl/hard/gf_14/etm_pre_script.tcl
@@ -1,1 +1,1 @@
-set_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"] -restore
+remove_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"]

--- a/bigblade_noc_io_link/tcl/hard/gf_14/etm_pre_script.tcl
+++ b/bigblade_noc_io_link/tcl/hard/gf_14/etm_pre_script.tcl
@@ -1,1 +1,1 @@
-set_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"] -restore
+remove_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"]

--- a/bigblade_noc_mem_link/tcl/hard/gf_14/etm_pre_script.tcl
+++ b/bigblade_noc_mem_link/tcl/hard/gf_14/etm_pre_script.tcl
@@ -1,1 +1,1 @@
-set_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"] -restore
+remove_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"]

--- a/common/sdr/sdr_corner/tcl/hard/gf_14/etm_pre_script.tcl
+++ b/common/sdr/sdr_corner/tcl/hard/gf_14/etm_pre_script.tcl
@@ -1,1 +1,1 @@
-set_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"] -restore
+remove_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"]

--- a/common/sdr/sdr_horizontal/tcl/hard/gf_14/etm_pre_script.tcl
+++ b/common/sdr/sdr_horizontal/tcl/hard/gf_14/etm_pre_script.tcl
@@ -1,1 +1,1 @@
-set_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"] -restore
+remove_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"]

--- a/common/sdr/sdr_vertical/tcl/hard/gf_14/etm_pre_script.tcl
+++ b/common/sdr/sdr_vertical/tcl/hard/gf_14/etm_pre_script.tcl
@@ -1,1 +1,1 @@
-set_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"] -restore
+remove_disable_timing [get_pins -hier -filter "full_name=~*BSG_OSDR_DFFPOS_BSG_DONT_TOUCH/Q"]


### PR DESCRIPTION
set_disable_timing breaks the timing arch and is problematic for top-level routing.
Restore the timing arch right before etm generation.