### PR TITLE
add clk gen monitor ds param

### DIFF
--- a/common/v/bsg_chip_pkg.v
+++ b/common/v/bsg_chip_pkg.v
@@ -11,6 +11,7 @@ package bsg_chip_pkg;
 
   localparam bsg_link_clk_gen_ds_width_gp      = 6;
   localparam bsg_link_clk_gen_num_adgs_gp      = 1;
+  localparam bsg_link_clk_gen_lg_monitor_ds_gp = 5;
 
 
   //////////////////////////////////////////////////


### PR DESCRIPTION
For now I set the downsample ratio to 2^5 (32), so that when running at 2 GHz the monitor frequency is 62.5 MHz.

This requires 5 flops and 5 inverters added to clk_gen block.