### PR TITLE
add shared memgen script to bigblade_toplevel

### DIFF
--- a/bigblade_toplevel/scripts/harden/bsg_14.memgen.json
+++ b/bigblade_toplevel/scripts/harden/bsg_14.memgen.json
@@ -1,4 +1,14 @@
 {
-  "memories" : [],
+  "memories" : [
+    {"name": "gf14_1rw_d1024_w46_m4",      "width":  46, "depth": 1024, "mux": 4, "mask": 0, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d1024_w32_m4_byte", "width":  32, "depth": 1024, "mux": 4, "mask": 8, "banks": 1, "type": "rf"   },
+  
+    {"name": "gf14_1rw_d512_w128_m2_byte",    "width":  128,  "depth": 512, "mux": 2, "mask": 8, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d64_w80_m2_bit",       "width":  80,   "depth": 64,  "mux": 2, "mask": 1, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d64_w7_m4_bit",        "width":  7,    "depth": 64,  "mux": 4, "mask": 1, "banks": 1, "type": "rf"   },
+
+    {"name": "gf14_1r1w_d64_w34_m1",       "width":  34, "depth":   64, "mux": 1, "mask": 0, "banks": 2, "type": "2rf"  },
+    {"name": "gf14_1r1w_d64_w31_m2",       "width":  31, "depth":   64, "mux": 2, "mask": 0, "banks": 2, "type": "2rf"  }
+  ],
   "dont_compile" : []
 }


### PR DESCRIPTION
hardened mems should be generated in bigblade_toplevel dir, and leaf modules should point to the same pdk_prep