### PR TITLE
Switch verbose_p to 0, to reduce SPMD loader messages

### DIFF
--- a/bigblade_toplevel/testing/v/bsg_gateway_chip_core_complex.v
+++ b/bigblade_toplevel/testing/v/bsg_gateway_chip_core_complex.v
@@ -70,7 +70,7 @@ module bsg_gateway_chip_core_complex
     ,.y_cord_width_p(hb_y_cord_width_gp)
     ,.io_x_cord_p(7'b0001111)
     ,.io_y_cord_p(7'b0001000)
-    ,.verbose_p(1)
+    ,.verbose_p(0)
   ) host (
     .clk_i(mc_clk_i)
     ,.reset_i(~tag_trace_done_i)


### PR DESCRIPTION
The number of SPMD loader messages increases simulation time and log file size.

In [#531](https://github.com/bespoke-silicon-group/bsg_manycore/pull/531) in bsg_manycore I changed spmd loader to print every 1024 cycles when when verbose_p is 0, so that we can still see a spmd loader heartbeat. 