### PR TITLE
Add heartbeat to manycore cycle counter

### DIFF
--- a/bigblade_toplevel/testing/v/bsg_gateway_chip_core_complex.v
+++ b/bigblade_toplevel/testing/v/bsg_gateway_chip_core_complex.v
@@ -159,9 +159,20 @@ module bsg_gateway_chip_core_complex
      ,.reset_i(~tag_trace_done_i)
      ,.ctr_r_o(cycle_counter)
      );
-   
+  always @(negedge mc_clk_i) begin
+    if(tag_trace_done_i && (cycle_counter % 1024 == 0)) begin
+      reg [63:0] t;
+      int fd;
+      t = 0;
+      $system("date +%s%3N > date.txt");
+      fd=$fopen("date.txt","r");
+      $fscanf(fd, "%d", t);
+      $fclose(fd);
+      $display("BSG SIM HEARTBEAT: %d manycore compute cycles completed @ %d ms", cycle_counter, t);
+    end
+  end
   final begin
-     $display("BSG INFO: %d cycles completed @ finish", cycle_counter);
+    $display("BSG INFO: %d cycles completed @ finish", cycle_counter);
   end
   // synopsys translate on
 endmodule


### PR DESCRIPTION
Prints out: 

```BSG SIM HEARTBEAT:                 1024 manycore compute cycles completed @        1622828148958 ms```

Every 1024 manycore cycles. I picked this because it prints out every ~second in RTL, which would mean every 30 seconds in Synthesis or every couple minutes in slower simulations. 